### PR TITLE
[RAINCATCH 449] Implement simple-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# FeedHenry RainCatcher Simple Store
+
+A CRUD storage engine that supports both in-memory and $fh.db backends.
+
+# Usage
+
+The initial config requires an entity name and the initial seed data:
+
+```javascript
+const Store = require('fh-wfm-simple-store');
+const store = new Store('user');
+store.init({ ... }).then(function() {
+  // store is available for use
+});
+```
+
+You can additionally utilize the `listen` method to have the story listen to conventially-named mediator topics.
+
+```javascript
+const store = new Store('user');
+store.init({}).then(function() {
+  store.listen('', mediator);
+  mediator.request('wfm:user:list').then(console.log);
+  // the above pattern is also available through the `topics` property:
+  store.topics.request('list').then(console.log);
+})
+```
+
+# DB Api
+The `$fh.db` backend utilizes the storage engine provided by the FeedHenry Cloud API, wrapped by the Simple Store API and is activated when the `WFM_USE_MEMORY_STORE` enviroment variable is set to `false`. The general configuration is done via environment variables.
+
+During execution, you can detect if the storage engine being used utilizes a persistent backend via the `{store}.isPersistent` property.
+
+The documentation for `$fh.db` is available [here](https://access.redhat.com/documentation/en/red-hat-mobile-application-platform-hosted/3/paged/cloud-api/chapter-2-fhdb).

--- a/lib/array-store.js
+++ b/lib/array-store.js
@@ -75,9 +75,10 @@ ArrayStore.prototype.listen = function(topicPrefix, mediator) {
 
   self.topic.create = "wfm:" + topicPrefix + self.datasetId + ':create';
   console.log('Subscribing to mediator topic:', self.topic.create);
-  self.subscription.create = mediator.subscribe(self.topic.create, function(object, ts) {
-    self.create(object, ts).then(function(object) {
-      mediator.publish('done:' + self.topic.create + ':' + ts, object);
+  self.subscription.create = mediator.subscribe(self.topic.create, function(object) {
+    var uid = object.id;
+    self.create(object).then(function(object) {
+      mediator.publish('done:' + self.topic.create + ':' + uid, object);
     });
   });
 

--- a/lib/array-store.js
+++ b/lib/array-store.js
@@ -68,60 +68,6 @@ ArrayStore.prototype.deleteAll = function() {
   return Promise.resolve(true);
 };
 
-
-ArrayStore.prototype.listen = function(topicPrefix, mediator) {
-  var self = this;
-  self.mediator = mediator;
-
-  self.topic.create = "wfm:" + topicPrefix + self.datasetId + ':create';
-  console.log('Subscribing to mediator topic:', self.topic.create);
-  self.subscription.create = mediator.subscribe(self.topic.create, function(object) {
-    var uid = object.id;
-    self.create(object).then(function(object) {
-      mediator.publish('done:' + self.topic.create + ':' + uid, object);
-    });
-  });
-
-  self.topic.load = "wfm:" + topicPrefix + self.datasetId + ':read';
-  console.log('Subscribing to mediator topic:', self.topic.load);
-  self.subscription.load = mediator.subscribe(self.topic.load, function(id) {
-    self.read(id).then(function(object) {
-      mediator.publish('done:' + self.topic.load + ':' + id, object);
-    });
-  });
-
-  self.topic.save = "wfm:" + topicPrefix + self.datasetId + ':update';
-  console.log('Subscribing to mediator topic:', self.topic.save);
-  self.subscription.save = mediator.subscribe(self.topic.save, function(object) {
-    self.update(object).then(function(object) {
-      mediator.publish('done:' + self.topic.save + ':' + object.id, object);
-    });
-  });
-
-  self.topic.delete = "wfm:" + topicPrefix + self.datasetId + ':delete';
-  console.log('Subscribing to mediator topic:', self.topic.delete);
-  self.subscription.delete = mediator.subscribe(self.topic.delete, function(object) {
-    self.delete(object).then(function(object) {
-      mediator.publish('done:' + self.topic.delete + ':' + object.id, object);
-    });
-  });
-
-  self.topic.list = "wfm:" + topicPrefix + self.datasetId + ':list';
-  console.log('Subscribing to mediator topic:', self.topic.list);
-  self.subscription.list = mediator.subscribe(self.topic.list, function(queryParams) {
-    var filter = queryParams && queryParams.filter || {};
-    self.list(filter).then(function(list) {
-      mediator.publish('done:' + self.topic.list, list);
-    });
-  });
-};
-
-ArrayStore.prototype.unsubscribe = function() {
-  this.mediator.remove(this.topic.list, this.subscription.list.id);
-  this.mediator.remove(this.topic.load, this.subscription.load.id);
-  this.mediator.remove(this.topic.save, this.subscription.save.id);
-  this.mediator.remove(this.topic.create, this.subscription.create.id);
-  this.mediator.remove(this.topic.delete, this.subscription.delete.id);
-};
+require('./listen')(ArrayStore);
 
 module.exports = ArrayStore;

--- a/lib/array-store.js
+++ b/lib/array-store.js
@@ -27,7 +27,7 @@ ArrayStore.prototype.read = function(id) {
   var object = _.find(this.data, function(_object) {
     return String(_object.id) === String(id);
   });
-  return Promise.resolve(object);
+  return Promise.resolve(_.clone(object));
 };
 
 ArrayStore.prototype.update = function(object) {
@@ -60,7 +60,7 @@ ArrayStore.prototype.list = function(filter) {
   } else {
     filterResults = this.data;
   }
-  return Promise.resolve(filterResults);
+  return Promise.resolve(_.cloneDeep(filterResults));
 };
 
 ArrayStore.prototype.deleteAll = function() {

--- a/lib/fh-db-store.js
+++ b/lib/fh-db-store.js
@@ -1,5 +1,6 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
+const shortid = require('shortid');
 const db = Promise.promisify(require('fh-mbaas-api').db);
 'use strict';
 
@@ -35,6 +36,7 @@ Store.prototype.init = function(data) {
 Store.prototype.isPersistent = true;
 
 Store.prototype.create = function(object) {
+  object.id = shortid.generate();
   return db({
     act: 'create',
     type: this.datasetId,
@@ -111,5 +113,7 @@ Store.prototype.deleteAll = function() {
     type: this.datasetId
   });
 };
+
+require('./listen')(Store);
 
 module.exports = Store;

--- a/lib/fh-db-store.js
+++ b/lib/fh-db-store.js
@@ -9,8 +9,6 @@ const extractListFields = function(res) {
 };
 
 function Store(datasetId) {
-  this.topic = {};
-  this.subscription = {};
   this.datasetId = datasetId;
 }
 

--- a/lib/listen.js
+++ b/lib/listen.js
@@ -1,0 +1,56 @@
+module.exports = function decorate(Class) {
+  Class.prototype.listen = function(topicPrefix, mediator) {
+    var self = this;
+    self.mediator = mediator;
+
+    self.topic.create = "wfm:" + topicPrefix + self.datasetId + ':create';
+    console.log('Subscribing to mediator topic:', self.topic.create);
+    self.subscription.create = mediator.subscribe(self.topic.create, function(object) {
+      var uid = object.id;
+      self.create(object).then(function(object) {
+        mediator.publish('done:' + self.topic.create + ':' + uid, object);
+      });
+    });
+
+    self.topic.load = "wfm:" + topicPrefix + self.datasetId + ':read';
+    console.log('Subscribing to mediator topic:', self.topic.load);
+    self.subscription.load = mediator.subscribe(self.topic.load, function(id) {
+      self.read(id).then(function(object) {
+        mediator.publish('done:' + self.topic.load + ':' + id, object);
+      });
+    });
+
+    self.topic.save = "wfm:" + topicPrefix + self.datasetId + ':update';
+    console.log('Subscribing to mediator topic:', self.topic.save);
+    self.subscription.save = mediator.subscribe(self.topic.save, function(object) {
+      self.update(object).then(function(object) {
+        mediator.publish('done:' + self.topic.save + ':' + object.id, object);
+      });
+    });
+
+    self.topic.delete = "wfm:" + topicPrefix + self.datasetId + ':delete';
+    console.log('Subscribing to mediator topic:', self.topic.delete);
+    self.subscription.delete = mediator.subscribe(self.topic.delete, function(object) {
+      self.delete(object).then(function(object) {
+        mediator.publish('done:' + self.topic.delete + ':' + object.id, object);
+      });
+    });
+
+    self.topic.list = "wfm:" + topicPrefix + self.datasetId + ':list';
+    console.log('Subscribing to mediator topic:', self.topic.list);
+    self.subscription.list = mediator.subscribe(self.topic.list, function(queryParams) {
+      var filter = queryParams && queryParams.filter || {};
+      self.list(filter).then(function(list) {
+        mediator.publish('done:' + self.topic.list, list);
+      });
+    });
+  };
+
+  Class.prototype.unsubscribe = function() {
+    this.mediator.remove(this.topic.list, this.subscription.list.id);
+    this.mediator.remove(this.topic.load, this.subscription.load.id);
+    this.mediator.remove(this.topic.save, this.subscription.save.id);
+    this.mediator.remove(this.topic.create, this.subscription.create.id);
+    this.mediator.remove(this.topic.delete, this.subscription.delete.id);
+  };
+};

--- a/lib/listen.js
+++ b/lib/listen.js
@@ -1,56 +1,27 @@
+const Topics = require('fh-wfm-mediator/lib/topics');
 module.exports = function decorate(Class) {
   Class.prototype.listen = function(topicPrefix, mediator) {
     var self = this;
-    self.mediator = mediator;
-
-    self.topic.create = "wfm:" + topicPrefix + self.datasetId + ':create';
-    console.log('Subscribing to mediator topic:', self.topic.create);
-    self.subscription.create = mediator.subscribe(self.topic.create, function(object) {
-      var uid = object.id;
-      self.create(object).then(function(object) {
-        mediator.publish('done:' + self.topic.create + ':' + uid, object);
-      });
-    });
-
-    self.topic.load = "wfm:" + topicPrefix + self.datasetId + ':read';
-    console.log('Subscribing to mediator topic:', self.topic.load);
-    self.subscription.load = mediator.subscribe(self.topic.load, function(id) {
-      self.read(id).then(function(object) {
-        mediator.publish('done:' + self.topic.load + ':' + id, object);
-      });
-    });
-
-    self.topic.save = "wfm:" + topicPrefix + self.datasetId + ':update';
-    console.log('Subscribing to mediator topic:', self.topic.save);
-    self.subscription.save = mediator.subscribe(self.topic.save, function(object) {
-      self.update(object).then(function(object) {
-        mediator.publish('done:' + self.topic.save + ':' + object.id, object);
-      });
-    });
-
-    self.topic.delete = "wfm:" + topicPrefix + self.datasetId + ':delete';
-    console.log('Subscribing to mediator topic:', self.topic.delete);
-    self.subscription.delete = mediator.subscribe(self.topic.delete, function(object) {
-      self.delete(object).then(function(object) {
-        mediator.publish('done:' + self.topic.delete + ':' + object.id, object);
-      });
-    });
-
-    self.topic.list = "wfm:" + topicPrefix + self.datasetId + ':list';
-    console.log('Subscribing to mediator topic:', self.topic.list);
-    self.subscription.list = mediator.subscribe(self.topic.list, function(queryParams) {
-      var filter = queryParams && queryParams.filter || {};
-      self.list(filter).then(function(list) {
-        mediator.publish('done:' + self.topic.list, list);
-      });
-    });
+    this.topics = new Topics(mediator);
+    this.mediator = mediator;
+    this.topics
+      .prefix('wfm' + topicPrefix)
+      .entity(this.datasetId)
+      .on('create', function(object) {
+        // needs a custom function because the created id is different
+        // than the one in the request() topic
+        var uid = object.id;
+        self.create(object).then(function(object) {
+          self.mediator.publish([self.topics.getTopic('create', 'done'), uid].join(':'), object);
+        });
+      })
+      .on('read', this.read.bind(this))
+      .on('update', this.update.bind(this))
+      .on('delete', this.delete.bind(this))
+      .on('list', this.list.bind(this));
   };
 
   Class.prototype.unsubscribe = function() {
-    this.mediator.remove(this.topic.list, this.subscription.list.id);
-    this.mediator.remove(this.topic.load, this.subscription.load.id);
-    this.mediator.remove(this.topic.save, this.subscription.save.id);
-    this.mediator.remove(this.topic.create, this.subscription.create.id);
-    this.mediator.remove(this.topic.delete, this.subscription.delete.id);
+    this.topics.unsubscribeAll();
   };
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "fh-mbaas-api": "^6.1.1",
-    "fh-wfm-mediator": "0.0.15",
+    "fh-wfm-mediator": "0.1.0-rc1",
     "lodash": "^4.17.2",
     "shortid": "^2.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "fh-mbaas-api": "^6.1.1",
+    "fh-wfm-mediator": "0.0.15",
     "lodash": "^4.17.2",
     "shortid": "^2.2.6"
   },

--- a/test/store.js
+++ b/test/store.js
@@ -28,12 +28,35 @@ module.exports = function(Store, describeDescription) {
           assert.equal(res.length, fixtures.length);
         });
       });
+      it('should not allow edits', function() {
+        var origUsername;
+        return this.store.list().then(function(res) {
+          var item = res[0];
+          origUsername = item.username;
+          item.username = 'bogus';
+        }).then(this.store.list.bind(this.store))
+        .then(function(res) {
+          var item = res[0];
+          assert.equal(item.username, origUsername);
+        });
+      });
     });
 
     describe('#read', function() {
       it('should find an item by id', function() {
         return this.store.read(daisyId).then(function(daisy) {
           assert(daisy.username === 'daisy');
+        });
+      });
+      it('should not allow edits', function() {
+        var self = this;
+        return this.store.read(daisyId).then(function(daisy) {
+          daisy.username = 'donald duck';
+        }).then(function() {
+          return self.store.read(daisyId);
+        }).then(function(daisy2) {
+          assert(daisy2);
+          assert.equal(daisy2.username, 'daisy');
         });
       });
       it('should resolve with nothing when not found', function() {

--- a/test/store.js
+++ b/test/store.js
@@ -99,23 +99,23 @@ module.exports = function(Store, describeDescription) {
       });
       it('should listen to the create topic', function() {
         // expected to answer at done:wfm:user:create:testid
-        return mediator.request('wfm:user:create', {id: 'testid', username: 'test'},
-          {uid: 'testid'}).then(function(res) {
+        return this.store.topics.request('create', {id: 'testid', username: 'test'},
+          {uid: 'testid'})
+          .then(function(res) {
             assert(res);
-            console.log(res)
             assert.notEqual(res.id, 'testid', 'create() should generate a new id');
             assert.equal(res.username, 'test');
           });
       });
       it('should listen to the read topic', function() {
         // expected to answer at done:wfm:user:read:${daisyId}
-        return mediator.request('wfm:user:read', daisyId).then(function(res) {
+        return this.store.topics.request('read', daisyId).then(function(res) {
           assert.equal(res.username, 'daisy');
         });
       });
       it('should listen to the update topic', function() {
         // expected to answer at done:wfm:user:update:${daisyId}
-        return mediator.request('wfm:user:update', {id: daisyId, position: 'test'},
+        return this.store.topics.request('update', {id: daisyId, position: 'test'},
           {uid: daisyId}).then(function(res) {
             assert.equal(res.username, 'daisy');
             assert.equal(res.position, 'test');
@@ -123,14 +123,14 @@ module.exports = function(Store, describeDescription) {
       });
       it('should listen to the delete topic', function() {
         // expected to answer at done:wfm:user:delete:${daisyId}
-        return mediator.request('wfm:user:delete', {id: daisyId, position: 'test'},
+        return this.store.topics.request('delete', {id: daisyId, position: 'test'},
           {uid: daisyId}).then(function(res) {
             assert.equal(res.username, 'daisy');
           });
       });
       it('should listen to the list topic', function() {
         // expected to answer at done:wfm:user:list
-        return mediator.request('wfm:user:list').then(function(res) {
+        return this.store.topics.request('list').then(function(res) {
           assert.equal(res.length, 8);
         });
       });

--- a/test/store.js
+++ b/test/store.js
@@ -101,6 +101,8 @@ module.exports = function(Store, describeDescription) {
         // expected to answer at done:wfm:user:create:testid
         return mediator.request('wfm:user:create', {id: 'testid', username: 'test'},
           {uid: 'testid'}).then(function(res) {
+            assert(res);
+            console.log(res)
             assert.notEqual(res.id, 'testid', 'create() should generate a new id');
             assert.equal(res.username, 'test');
           });

--- a/test/store.js
+++ b/test/store.js
@@ -4,6 +4,7 @@
 const fixtures = require('./fixtures');
 const assert = require('assert');
 const daisyId = 'rJeXyfdrH';
+const mediator = require('fh-wfm-mediator/lib/mediator');
 const newItem = {
   "username" : "jdoe",
   "name" : "John Doe",
@@ -89,6 +90,50 @@ module.exports = function(Store, describeDescription) {
         return this.store.delete('invalid_id').then(function(user) {
           assert.equal(user, null);
         });
+      });
+    });
+
+    describe('#listen', function() {
+      beforeEach(function() {
+        this.store.listen('', mediator);
+      });
+      it('should listen to the create topic', function() {
+        // expected to answer at done:wfm:user:create:testid
+        return mediator.request('wfm:user:create', {id: 'testid', username: 'test'},
+          {uid: 'testid'}).then(function(res) {
+            assert.notEqual(res.id, 'testid', 'create() should generate a new id');
+            assert.equal(res.username, 'test');
+          });
+      });
+      it('should listen to the read topic', function() {
+        // expected to answer at done:wfm:user:read:${daisyId}
+        return mediator.request('wfm:user:read', daisyId).then(function(res) {
+          assert.equal(res.username, 'daisy');
+        });
+      });
+      it('should listen to the update topic', function() {
+        // expected to answer at done:wfm:user:update:${daisyId}
+        return mediator.request('wfm:user:update', {id: daisyId, position: 'test'},
+          {uid: daisyId}).then(function(res) {
+            assert.equal(res.username, 'daisy');
+            assert.equal(res.position, 'test');
+          });
+      });
+      it('should listen to the delete topic', function() {
+        // expected to answer at done:wfm:user:delete:${daisyId}
+        return mediator.request('wfm:user:delete', {id: daisyId, position: 'test'},
+          {uid: daisyId}).then(function(res) {
+            assert.equal(res.username, 'daisy');
+          });
+      });
+      it('should listen to the list topic', function() {
+        // expected to answer at done:wfm:user:list
+        return mediator.request('wfm:user:list').then(function(res) {
+          assert.equal(res.length, 8);
+        });
+      });
+      afterEach(function() {
+        this.store.unsubscribe();
       });
     });
 


### PR DESCRIPTION
# Changes
- Refactor `listen` functionality to become available to both storage engines, and utilize the new mediator/lib/topics convenience lib.
- Add README

This is utilizing a published release-candidate from the mediator lib, this needs to be updated for a release
see https://github.com/feedhenry-raincatcher/raincatcher-mediator/tree/release/0.1.0