### PR TITLE
remove nsp from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
     mongo raincatcher --eval 'db.createUser({user: "user", pwd: "pw", roles: ["readWrite"]});'
 script:
   - npm test
-  - npm run vuln; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "author": "FeedHenry <npm@feedhenry.com>",
   "license": "MIT",
   "scripts": {
-    "test": "grunt unit",
-    "vuln": "nsp check"
+    "test": "grunt unit"
   },
   "dependencies": {
     "bluebird": "^3.4.7",
@@ -25,6 +24,5 @@
     "grunt-eslint": "^19.0.0",
     "grunt-mocha-test": "^0.13.2",
     "mocha": "^3.2.0",
-    "nsp": "^2.6.2"
   }
 }


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.