### PR TITLE
Allow for custom ids for new items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cov-*
 coverage
 plato
 .idea
+.vscode

--- a/lib/array-store.js
+++ b/lib/array-store.js
@@ -18,7 +18,10 @@ ArrayStore.prototype.init = function(data) {
 ArrayStore.prototype.isPersistent = false;
 
 ArrayStore.prototype.create = function(object) {
-  object.id = shortid.generate();
+  object = object || {};
+  if (!object.id) {
+    object.id = shortid.generate();
+  }
   this.data.push(object);
   return Promise.resolve(object);
 };

--- a/lib/fh-db-store.js
+++ b/lib/fh-db-store.js
@@ -34,7 +34,10 @@ Store.prototype.init = function(data) {
 Store.prototype.isPersistent = true;
 
 Store.prototype.create = function(object) {
-  object.id = shortid.generate();
+  object = object || {};
+  if (!object.id) {
+    object.id = shortid.generate();
+  }
   return db({
     act: 'create',
     type: this.datasetId,

--- a/test/store.js
+++ b/test/store.js
@@ -5,6 +5,7 @@ const fixtures = require('./fixtures');
 const assert = require('assert');
 const daisyId = 'rJeXyfdrH';
 const mediator = require('fh-wfm-mediator/lib/mediator');
+const _ = require('lodash');
 const newItem = {
   "username" : "jdoe",
   "name" : "John Doe",
@@ -85,6 +86,12 @@ module.exports = function(Store, describeDescription) {
           assert(user.id);
         });
       });
+      it('should allow for a client code-supplied id', function() {
+        newItem.id = 'someId';
+        return this.store.create(newItem).then(function(user) {
+          assert.equal(user.id, 'someId');
+        });
+      });
     });
 
     describe('#update', function() {
@@ -126,7 +133,7 @@ module.exports = function(Store, describeDescription) {
           {uid: 'testid'})
           .then(function(res) {
             assert(res);
-            assert.notEqual(res.id, 'testid', 'create() should generate a new id');
+            assert.equal(res.id, 'testid', 'create() should use the provided id');
             assert.equal(res.username, 'test');
           });
       });


### PR DESCRIPTION
This change reverts a regression in the demo app's seed data that relies on statically-written ids for referential integrity.